### PR TITLE
feat(#14): md_to_text.py

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Build
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
         run: |
           make env test

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -37,5 +37,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.11
+      - name: Test
         run: |
           make env test

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -35,4 +35,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build
         run: |
-          make test
+          make env test

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -24,7 +24,7 @@ architect:
   - h1alexbel
 merge:
   script: |
-    make test
+    make env test
 release:
   script: |
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+)?$ ]] || exit -1

--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,21 @@
 
 .SHELLFLAGS: -e -o pipefail -c
 .ONESHELL:
-.PHONY: install collect metrics test
+.PHONY: env install collect metrics test
 .SILENT:
 
 ## The shell to use.
 SHELL := bash
 
-# @todo #1:45min Create test script for the whole package.
-#  We should create a script that would run all tests we have.
-#  Let's try to copy the model from cam shell tests:
-#  https://github.com/yegor256/cam/tree/master/tests. Don't forget to remove
-#  this puzzle.
+# Setup environment.
+env:
+	python3 -m pip install --upgrade pip
+	pip3 install -r requirements.txt
+
+# Test.
 test:
-	echo "Testing..."
+	export PYTHONPATH=.
+	python3 -m pytest tests
 
 # Install.
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 pandas==2.2.2
+markdown==3.6
+numpy==1.26.4
+beautifulsoup4==4.12.3
+pytest==8.2.1

--- a/steps/md_to_text.py
+++ b/steps/md_to_text.py
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import markdown
+from bs4 import BeautifulSoup
+
+"""
+Translate markdown to plain text.
+"""
+
+
+def to_text(input):
+    return BeautifulSoup(markdown.markdown(input), "html.parser").get_text(
+        separator=' ',
+        strip=True
+    )

--- a/tests/test_md_to_text.py
+++ b/tests/test_md_to_text.py
@@ -1,0 +1,55 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+from steps.md_to_text import to_text
+
+"""
+Test case for MdToText.
+"""
+
+
+class TestMdToText(unittest.TestCase):
+
+    def test_translates_markdown_to_text(self):
+        text = to_text(
+            """
+# Web Attack Cheat Sheet
+
+## Table of Contents
+- [Discovering](#discovering)
+  - [Targets](#targets)
+  - [IP Enumeration](#ip-enumeration)
+  - [Subdomain Enumeration](#subdomain-enumeration)
+  - [Wayback Machine](#wayback-machine)
+  - [Cache](#cache)
+            """
+        )
+        expected = (
+            "Web Attack Cheat Sheet Table of Contents Discovering Targets IP "
+            "Enumeration Subdomain Enumeration "
+            "Wayback Machine Cache"
+        )
+        self.assertEqual(
+            text,
+            expected,
+            f"Translated text {text} does not match with expected {expected}"
+        )


### PR DESCRIPTION
closes #14

<!-- start pr-codex -->

---

## PR-Codex overview
### Summary
This PR adds dependencies, updates setup scripts, and refactors code for markdown to plain text conversion.

### Detailed summary
- Added `markdown==3.6`, `numpy==1.26.4`, `beautifulsoup4==4.12.3`, `pytest==8.2.1` to `requirements.txt`
- Updated setup script in `.rultor.yml` and `.github/workflows/make.yml`
- Refactored `Makefile` to include an `env` target and updated test script
- Added a script to convert markdown to plain text
- Implemented a test case for markdown to text conversion

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->