### PR TITLE
feat(#15): embed.py, infer

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -28,6 +28,8 @@ on:
   pull_request:
     branches:
       - master
+env:
+  HF_TESTING_TOKEN: ${{ secrets.HF_TESTING_TOKEN }}
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy==1.26.4
 beautifulsoup4==4.12.3
 pytest==8.2.1
 langdetect==1.0.9
+requests==2.32.3

--- a/steps/data.sh
+++ b/steps/data.sh
@@ -27,3 +27,4 @@ set -o pipefail
 cd steps
 $PYTHON structure.py
 $PYTHON filter.py
+$PYTHON embed.py

--- a/steps/embed.py
+++ b/steps/embed.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+
+import pandas as pd
+import requests
+
+print("Preparing for generating embeddings...")
+checkpoint = "sentence-transformers/all-MiniLM-L6-v2"
+token = os.environ["HF_TOKEN"]
+source = "filtered.csv"
+frame = pd.read_csv(source)
+candidates = ["description", "readme", "topics"]
+print(f"Checkpoint: {checkpoint}")
+print(f"CSV Source: {source}")
+print(f"Candidates: {candidates}")
+
+
+def query(texts):
+    return requests.post(
+        f"https://api-inference.huggingface.co/pipeline/feature-extraction/{checkpoint}",
+        headers={
+            "Authorization": f"Bearer {token}"
+        },
+        json={
+            "inputs": texts,
+            "options": {
+                "wait_for_model": True
+            }
+        }
+    ).json()
+
+
+for candidate in candidates:
+    print(f"Generating embeddings for {candidate}...")
+    embeddings = pd.DataFrame(query(frame[candidate].tolist()))
+    embeddings.to_csv(f"{candidate}-embeddings.csv", index=False)
+    print(f"Generated embeddings for {candidate}:")
+    print(embeddings)

--- a/steps/inference.py
+++ b/steps/inference.py
@@ -17,23 +17,23 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
-import pandas as pd
-from steps.inference import infer
+import requests
 
-print("Preparing for generating embeddings...")
-checkpoint = "sentence-transformers/all-MiniLM-L6-v2"
-token = os.environ["HF_TOKEN"]
-source = "filtered.csv"
-frame = pd.read_csv(source)
-candidates = ["description", "readme", "topics"]
-print(f"Checkpoint: {checkpoint}")
-print(f"CSV Source: {source}")
-print(f"Candidates: {candidates}")
+"""
+Infer textual metadata.
+"""
 
-for candidate in candidates:
-    print(f"Generating embeddings for {candidate}...")
-    embeddings = pd.DataFrame(infer(frame[candidate].tolist(), checkpoint, token))
-    embeddings.to_csv(f"{candidate}-embeddings.csv", index=False)
-    print(f"Generated embeddings for {candidate}:")
-    print(embeddings)
+
+def infer(texts, checkpoint, token):
+    return requests.post(
+        f"https://api-inference.huggingface.co/pipeline/feature-extraction/{checkpoint}",
+        headers={
+            "Authorization": f"Bearer {token}"
+        },
+        json={
+            "inputs": texts,
+            "options": {
+                "wait_for_model": True
+            }
+        }
+    ).json()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -18,22 +18,36 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import os
+import unittest
 import pandas as pd
+
 from steps.inference import infer
 
-print("Preparing for generating embeddings...")
-checkpoint = "sentence-transformers/all-MiniLM-L6-v2"
-token = os.environ["HF_TOKEN"]
-source = "filtered.csv"
-frame = pd.read_csv(source)
-candidates = ["description", "readme", "topics"]
-print(f"Checkpoint: {checkpoint}")
-print(f"CSV Source: {source}")
-print(f"Candidates: {candidates}")
+"""
+Test case for inference.
+"""
 
-for candidate in candidates:
-    print(f"Generating embeddings for {candidate}...")
-    embeddings = pd.DataFrame(infer(frame[candidate].tolist(), checkpoint, token))
-    embeddings.to_csv(f"{candidate}-embeddings.csv", index=False)
-    print(f"Generated embeddings for {candidate}:")
-    print(embeddings)
+
+class TestInference(unittest.TestCase):
+
+    def test_infers_text(self):
+        embeddings = infer(
+            ["this is testing text"],
+            "sentence-transformers/all-MiniLM-L6-v2",
+            os.environ["HF_TESTING_TOKEN"]
+        )
+        frame = pd.DataFrame(embeddings)
+        columns = len(frame.columns)
+        cexpected = 384
+        rows = len(frame)
+        rexpected = 1
+        self.assertEqual(
+            rows,
+            rexpected,
+            f"Generated embeddings rows count {rows} does not match with expected {rexpected}"
+        )
+        self.assertEqual(
+            columns,
+            cexpected,
+            f"Generated embeddings columns count {columns} does not match with expected {cexpected}"
+        )


### PR DESCRIPTION
closes #15

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `embed.py` script for generating embeddings from textual data using the Hugging Face pipeline. It also includes necessary functions for inference and tests.

### Detailed summary
- Added `embed.py` script for generating embeddings
- Included `infer` function for textual metadata inference
- Added tests for the `infer` function in `test_inference.py`
- Updated `requirements.txt` with `requests==2.32.3`
- Modified GitHub workflow to include `HF_TESTING_TOKEN` secret
- Provided copyright notice in `inference.py`, `test_inference.py`, and `embed.py`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->