### PR TITLE
feat(#29): numerics, filter push to repos.csv directly

### DIFF
--- a/steps/apply_filter.py
+++ b/steps/apply_filter.py
@@ -48,6 +48,5 @@ def apply(csv):
     print(f"Skipped {skipped_non_english} non-english repositories")
     print(f"Total skipped: {skipped + skipped_non_english}")
     print(f"Staying with {len(frame)} good repositories")
-    frame.to_csv("filtered.csv", index=False)
     print(frame)
     return frame

--- a/steps/numerics.py
+++ b/steps/numerics.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # The MIT License (MIT)
 #
 # Copyright (c) 2024 Aliaksei Bialiauski
@@ -20,12 +19,27 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-"""
-Filter dataset.
-"""
 import os
-from steps.apply_filter import apply
 
-csv = os.environ["CSV"]
-apply(f"{csv}.csv").to_csv(csv, index=False)
+import pandas as pd
+
+"""
+Prepare dataset with numerics only.
+"""
+print("Preparing numerics dataset...")
+frame = pd.read_csv(f"{os.environ['CSV']}.csv")
+frame = frame[
+    [
+        "repo",
+        "releases",
+        "contributors",
+        "pulls",
+        "commits",
+        "issues",
+        "branches",
+        "workflows"
+    ]
+]
+frame.to_csv("numerics.csv", index=False)
+print("Numerics dataset:")
+print(frame)

--- a/tests/test_apply_filter.py
+++ b/tests/test_apply_filter.py
@@ -19,7 +19,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
 import unittest
 
 import pandas as pd
@@ -32,9 +31,6 @@ Test case for Apply Filter.
 
 
 class TestApplyFilter(unittest.TestCase):
-
-    def tearDown(self):
-        os.remove("filtered.csv")
 
     def test_filters_illegal_repos(self):
         frame = apply("tests/test.csv").reset_index(drop=True)


### PR DESCRIPTION
ref #29

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the filtering and processing of data in the project. It adds functionality to save filtered data to a CSV file, updates test cases, and prepares a dataset with numeric values only.

### Detailed summary
- `steps/filter.py`: Updated data processing to save filtered data to a CSV file.
- `steps/apply_filter.py`: Removed file deletion in test case teardown.
- `tests/test_apply_filter.py`: Updated test case for data filtering.
- `steps/numerics.py`: Added script to prepare a dataset with numeric values only.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->