### PR TITLE
feat(#43): look for CLUSTER=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,6 @@ test:
 	python3 -m pytest tests
 
 # Cluster.
-# @todo #37:30min Look for CLUSTER=true option in order to run clustering.
-#  We should run cluster.sh and zip.sh only if -e "CLUSTER=true" was passed
-#  inside the docker container. Don't forget to remove this puzzle.
 cluster:
 	chmod +x steps/cluster.sh &&./steps/cluster.sh
 	chmod +x steps/zip.sh &&./steps/zip.sh

--- a/steps/cluster.sh
+++ b/steps/cluster.sh
@@ -25,8 +25,13 @@ set -e
 set -o pipefail
 
 # Cluster the data.
-cd steps
-$PYTHON kmeans_numerical.py
-$PYTHON agglomerative_numerical.py
-$PYTHON dbscan_numerical.py
-$PYTHON gmm_numerical.py
+if [[ "$CLUSTER" = "true" ]]; then
+  echo "Run clustering since CLUSTER=true..."
+  cd steps
+  $PYTHON kmeans_numerical.py
+  $PYTHON agglomerative_numerical.py
+  $PYTHON dbscan_numerical.py
+  $PYTHON gmm_numerical.py
+else
+  exit 0
+fi


### PR DESCRIPTION
closes #43

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a conditional check for running clustering based on the `CLUSTER` option in the Makefile.

### Detailed summary
- Added conditional check to run clustering based on `CLUSTER` option.
- Cluster script now runs only if `CLUSTER=true`.
- Added check to exit if `CLUSTER` is not set to true.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->